### PR TITLE
Add cmake install rule for the sv-bugpoint binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,5 @@ if (NOT MSVC)
       target_compile_options(sv-bugpoint PRIVATE -Werror)
     endif()
 endif()
+
+install(TARGETS sv-bugpoint RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This makes sv-bugpoint a little easier to install and package.

*I have sv-bugpoint packaged in for nix in https://github.com/lowRISC/lowrisc-nix/pull/69*